### PR TITLE
Neighbour centers from `get_interp_weights` (Spin-2 preparation for furax)

### DIFF
--- a/jax_healpy/__init__.py
+++ b/jax_healpy/__init__.py
@@ -21,6 +21,7 @@ import jax
 from ._query_disc import estimate_disc_pixel_count, estimate_disc_radius, query_disc
 from .pixelfunc import (
     UNSEEN,
+    InterpCenters,
     ang2pix,
     ang2vec,
     get_all_neighbours,
@@ -87,6 +88,7 @@ __all__ = [
     'get_interp_weights',
     'get_interp_val',
     'get_all_neighbours',
+    'InterpCenters',
     # 'max_pixrad',
     'nest2ring',
     'ring2nest',

--- a/jax_healpy/pixelfunc.py
+++ b/jax_healpy/pixelfunc.py
@@ -84,6 +84,7 @@ Map data manipulation
 """
 
 from functools import partial
+from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -103,6 +104,7 @@ __all__ = [
     'get_interp_weights',
     'get_interp_val',
     'get_all_neighbours',
+    'InterpCenters',
     # 'max_pixrad',
     'nest2ring',
     'ring2nest',
@@ -1163,6 +1165,52 @@ def _get_ring_info(nside: int, ring_idx: ArrayLike) -> tuple[Array, Array, Array
     return theta, startpix, ringpix, shift
 
 
+def _get_ring_costheta_sintheta(nside: int, ring_idx: ArrayLike) -> tuple[Array, Array]:
+    """Get the cosine and sine of a ring's co-latitude, without forming the angle.
+
+    `_get_ring_info` computes both internally and then collapses them into an angle with
+    `arctan2`. Recovering them from that angle would round twice and lose accuracy near
+    the poles, which matters in float32.
+
+    Args:
+        nside (int): The healpix nside parameter.
+        ring_idx (ArrayLike): Ring index, 1 to 4*nside-1.
+
+    Returns:
+        tuple[Array, Array]: cos(theta) and sin(theta) of the ring. The sine is
+        non-negative.
+    """
+    ring = ring_idx
+
+    fact1 = 2.0 / (3.0 * nside)
+    fact2 = 4.0 / (12.0 * nside * nside)
+
+    # Northern hemisphere equivalent ring
+    northring = jnp.where(ring > 2 * nside, 4 * nside - ring, ring)
+
+    # Polar cap region (northring < nside): both are exact rearrangements of the
+    # HEALPix ring definition, with no cancellation in sin near the pole.
+    polar_tmp = northring * northring * fact2
+    polar_costheta = 1.0 - polar_tmp
+    polar_sintheta = jnp.sqrt(polar_tmp * (2.0 - polar_tmp))
+
+    # Equatorial region (northring >= nside): |z| <= 2/3, so sqrt(1 - z**2) is well
+    # conditioned everywhere in this branch. The clamp is for polar rings, where this
+    # branch is discarded but still evaluated, and would otherwise take sqrt of a
+    # negative number.
+    equatorial_costheta = (2.0 * nside - northring) * fact1
+    equatorial_sintheta = jnp.sqrt(jnp.maximum(1.0 - equatorial_costheta * equatorial_costheta, 0.0))
+
+    is_polar = northring < nside
+    costheta = jnp.where(is_polar, polar_costheta, equatorial_costheta)
+    sintheta = jnp.where(is_polar, polar_sintheta, equatorial_sintheta)
+
+    # Southern hemisphere correction: theta -> pi - theta flips the cosine, keeps the sine
+    costheta = jnp.where(northring != ring, -costheta, costheta)
+
+    return costheta, sintheta
+
+
 @jit(static_argnames=['nside', 'nest'])
 def pix2xyf(nside: int, ipix: ArrayLike, nest: bool = False) -> tuple[Array, Array, Array]:
     """pix2xyf : nside,ipix,nest=False -> x,y,face (default RING)
@@ -1708,10 +1756,39 @@ def reorder(
     return map_out
 
 
-@jit(static_argnames=['nside', 'nest', 'lonlat'])
+class InterpCenters(NamedTuple):
+    """Centers of the four interpolation neighbours returned by `get_interp_weights`.
+
+    The four neighbours lie on only two rings: rows 0 and 1 of `pixels` on the first,
+    rows 2 and 3 on the second. Co-latitude therefore has two values per sample, not
+    four, and is given as a cosine and a sine because that is the form the ring geometry
+    yields and the form spherical-transport consumers need.
+
+    Being a NamedTuple, this is a JAX pytree: it crosses `jit` boundaries and can be
+    `vmap`-ed. It also unpacks as a plain `(z, s, phi)` tuple.
+
+    Attributes:
+        z (Array): Shape (2, *dims). cos(theta) of the first and second ring.
+        s (Array): Shape (2, *dims). sin(theta) of the first and second ring,
+            non-negative.
+        phi (Array): Shape (4, *dims). Longitude of each neighbour in radians, in
+            [0, 2*pi), aligned row for row with `pixels`.
+    """
+
+    z: Array
+    s: Array
+    phi: Array
+
+
+@jit(static_argnames=['nside', 'nest', 'lonlat', 'with_centers'])
 def get_interp_weights(
-    nside: int, theta: ArrayLike, phi: ArrayLike | None = None, nest: bool = False, lonlat: bool = False
-) -> tuple[Array, Array]:
+    nside: int,
+    theta: ArrayLike,
+    phi: ArrayLike | None = None,
+    nest: bool = False,
+    lonlat: bool = False,
+    with_centers: bool = False,
+) -> tuple[Array, Array] | tuple[Array, Array, InterpCenters]:
     """Return interpolation weights for given coordinates.
 
     This function performs bilinear interpolation by finding the four
@@ -1730,6 +1807,9 @@ def get_interp_weights(
         If True, use NESTED pixel ordering (raises error)
     lonlat : bool, optional
         If True, interpret theta, phi as longitude, latitude in degrees
+    with_centers : bool, optional
+        If True, also return the centers of the four neighbours. Cheaper than a second
+        pix2ang pass, since the ring geometry is already computed internally.
 
     Returns
     -------
@@ -1740,6 +1820,9 @@ def get_interp_weights(
     weights : Array
         Array of shape (4, N) containing the interpolation weights.
         Weights sum to 1.0 for each point to machine precision.
+    centers : InterpCenters
+        Only if with_centers is True. Centers of the pixels in `pixels`, aligned row
+        for row with it whatever order `pixels` is in.
 
     Notes
     -----
@@ -1779,6 +1862,8 @@ def get_interp_weights(
     - Gradients of individual weights reflect the continuous dependence on coordinates
     - Gradients of sum(weights) are always zero since the sum is identically 1.0
     - Pixel indices have zero gradients since they are discrete selectors
+    - Neighbour centers likewise have zero gradients: they are fixed points of the
+      HEALPix grid, piecewise constant in (theta, phi)
 
     Example gradient usage:
 
@@ -1803,10 +1888,12 @@ def get_interp_weights(
             theta_coords, phi_coords = _lonlat2thetaphi(theta_coords, phi_coords)
 
     # Call the RING implementation
-    return _get_interp_weights_ring(nside, theta_coords, phi_coords)
+    return _get_interp_weights_ring(nside, theta_coords, phi_coords, with_centers)
 
 
-def _get_interp_weights_ring(nside: int, theta_coords: Array, phi_coords: Array) -> tuple[Array, Array]:
+def _get_interp_weights_ring(
+    nside: int, theta_coords: Array, phi_coords: Array, with_centers: bool = False
+) -> tuple[Array, Array] | tuple[Array, Array, InterpCenters]:
     """
     Memory-optimized implementation of bilinear interpolation for RING ordering.
 
@@ -1942,7 +2029,38 @@ def _get_interp_weights_ring(nside: int, theta_coords: Array, phi_coords: Array)
     weight_sum = jnp.sum(weights, axis=0, keepdims=True)
     weights = weights / weight_sum
 
-    return pixels, weights
+    if not with_centers:
+        return pixels, weights
+
+    # Co-latitude of the two rings. Safe in every branch: inside a cap the clamps above
+    # collapse ir1_safe and ir2_safe onto the same ring, which is the ring the four
+    # replacement pixels lie on, so the two entries simply coincide.
+    z1, s1 = _get_ring_costheta_sintheta(nside, ir1_safe)
+    z2, s2 = _get_ring_costheta_sintheta(nside, ir2_safe)
+
+    # Longitude. The ring grid describes the pixels that would have been returned, so it
+    # is only valid where the pole branches did not replace them. The four cap pixels sit
+    # at (k + 1/2) * pi/2, and their index modulo 4 is k in both caps, so read them off
+    # the final pixel values instead.
+    quarter_pi = 0.5 * jnp.pi
+    phi_ring1_1 = jnp.where(is_north_pole, ((pixels_ring1_1 & 3) + 0.5) * quarter_pi, (i1_1 + shift1) * dphi1)
+    phi_ring1_2 = jnp.where(is_north_pole, ((pixels_ring1_2 & 3) + 0.5) * quarter_pi, (i2_1 + shift1) * dphi1)
+    phi_ring2_1 = jnp.where(is_south_pole, ((pixels_ring2_1 & 3) + 0.5) * quarter_pi, (i1_2 + shift2) * dphi2)
+    phi_ring2_2 = jnp.where(is_south_pole, ((pixels_ring2_2 & 3) + 0.5) * quarter_pi, (i2_2 + shift2) * dphi2)
+
+    # Stop gradient: centers are fixed points of the HEALPix grid, piecewise constant in
+    # the input coordinates. Keeping them constant is also what leaves an interpolation
+    # operator built on them linear, hence transposable, in the map it interpolates.
+    dtype = weights.dtype
+    centers = lax.stop_gradient(
+        InterpCenters(
+            z=jnp.stack([z1, z2]).astype(dtype),
+            s=jnp.stack([s1, s2]).astype(dtype),
+            phi=jnp.stack([phi_ring1_1, phi_ring1_2, phi_ring2_1, phi_ring2_2]).astype(dtype),
+        )
+    )
+
+    return pixels, weights, centers
 
 
 @jit(static_argnames=['nest', 'lonlat'])

--- a/jax_healpy/pixelfunc.py
+++ b/jax_healpy/pixelfunc.py
@@ -1168,9 +1168,16 @@ def _get_ring_info(nside: int, ring_idx: ArrayLike) -> tuple[Array, Array, Array
 def _get_ring_costheta_sintheta(nside: int, ring_idx: ArrayLike) -> tuple[Array, Array]:
     """Get the cosine and sine of a ring's co-latitude, without forming the angle.
 
-    `_get_ring_info` computes both internally and then collapses them into an angle with
-    `arctan2`. Recovering them from that angle would round twice and lose accuracy near
-    the poles, which matters in float32.
+    `_get_ring_info` returns the angle, and recovering the cosine and sine from it would
+    round twice and lose accuracy near the poles, which matters in float32. It computes
+    both directly in its polar branch before collapsing them through `arctan2`, but its
+    equatorial branch goes straight to `arccos` and never forms a sine, so that half has
+    to be computed here regardless.
+
+    Kept separate rather than folded into `_get_ring_info` as an extra return value: both
+    run in the same jit trace on the same ring index, so XLA's common-subexpression
+    elimination already shares everything that overlaps. Merging them measures no faster
+    and would give a helper that `_query_disc` also calls a variable-arity return.
 
     Args:
         nside (int): The healpix nside parameter.

--- a/jax_healpy/pixelfunc.py
+++ b/jax_healpy/pixelfunc.py
@@ -2039,21 +2039,30 @@ def _get_interp_weights_ring(
     if not with_centers:
         return pixels, weights
 
+    # Read the ring geometry through a barrier. The centers share subexpressions with the
+    # weights, and without this XLA fuses those shared nodes differently once they have a
+    # second consumer. The co-latitude weight divides by theta2 - theta1 ~ 1/nside, so a
+    # one-ulp change there is amplified by about nside, which would make the weights
+    # depend on whether centers were requested.
+    (ir1_c, ir2_c, i1_1c, i2_1c, i1_2c, i2_2c, shift1_c, shift2_c, dphi1_c, dphi2_c) = lax.optimization_barrier(
+        (ir1_safe, ir2_safe, i1_1, i2_1, i1_2, i2_2, shift1, shift2, dphi1, dphi2)
+    )
+
     # Co-latitude of the two rings. Safe in every branch: inside a cap the clamps above
     # collapse ir1_safe and ir2_safe onto the same ring, which is the ring the four
     # replacement pixels lie on, so the two entries simply coincide.
-    z1, s1 = _get_ring_costheta_sintheta(nside, ir1_safe)
-    z2, s2 = _get_ring_costheta_sintheta(nside, ir2_safe)
+    z1, s1 = _get_ring_costheta_sintheta(nside, ir1_c)
+    z2, s2 = _get_ring_costheta_sintheta(nside, ir2_c)
 
     # Longitude. The ring grid describes the pixels that would have been returned, so it
     # is only valid where the pole branches did not replace them. The four cap pixels sit
     # at (k + 1/2) * pi/2, and their index modulo 4 is k in both caps, so read them off
     # the final pixel values instead.
     quarter_pi = 0.5 * jnp.pi
-    phi_ring1_1 = jnp.where(is_north_pole, ((pixels_ring1_1 & 3) + 0.5) * quarter_pi, (i1_1 + shift1) * dphi1)
-    phi_ring1_2 = jnp.where(is_north_pole, ((pixels_ring1_2 & 3) + 0.5) * quarter_pi, (i2_1 + shift1) * dphi1)
-    phi_ring2_1 = jnp.where(is_south_pole, ((pixels_ring2_1 & 3) + 0.5) * quarter_pi, (i1_2 + shift2) * dphi2)
-    phi_ring2_2 = jnp.where(is_south_pole, ((pixels_ring2_2 & 3) + 0.5) * quarter_pi, (i2_2 + shift2) * dphi2)
+    phi_ring1_1 = jnp.where(is_north_pole, ((pixels[0] & 3) + 0.5) * quarter_pi, (i1_1c + shift1_c) * dphi1_c)
+    phi_ring1_2 = jnp.where(is_north_pole, ((pixels[1] & 3) + 0.5) * quarter_pi, (i2_1c + shift1_c) * dphi1_c)
+    phi_ring2_1 = jnp.where(is_south_pole, ((pixels[2] & 3) + 0.5) * quarter_pi, (i1_2c + shift2_c) * dphi2_c)
+    phi_ring2_2 = jnp.where(is_south_pole, ((pixels[3] & 3) + 0.5) * quarter_pi, (i2_2c + shift2_c) * dphi2_c)
 
     # Stop gradient: centers are fixed points of the HEALPix grid, piecewise constant in
     # the input coordinates. Keeping them constant is also what leaves an interpolation

--- a/tests/pixelfunc/test_interp.py
+++ b/tests/pixelfunc/test_interp.py
@@ -362,16 +362,22 @@ def test_get_interp_weights_centers_shapes_and_ranges(nside, branch):
 
 
 @pytest.mark.parametrize('branch', ['north cap', 'belt', 'south cap'])
-@pytest.mark.parametrize('nside', [16, 128])
+@pytest.mark.parametrize('nside', [16, 128, 1024])
 def test_get_interp_weights_centers_do_not_perturb_pixels(nside, branch):
-    """Asking for centers must not change what the function returns otherwise."""
+    """Asking for centers must not change what the function returns otherwise.
+
+    Bit equality, not closeness. The centers share subexpressions with the weights, and
+    the co-latitude weight divides by theta2 - theta1, which is of order 1/nside, so a
+    one-ulp change in a shared node is amplified by about nside. An `optimization_barrier`
+    keeps the two paths apart; without it this assertion fails.
+    """
     theta, phi = _branch_targets(nside, branch)
 
     pixels_ref, weights_ref = jhp.get_interp_weights(nside, theta, phi)
     pixels, weights, _ = jhp.get_interp_weights(nside, theta, phi, with_centers=True)
 
     np.testing.assert_array_equal(np.asarray(pixels), np.asarray(pixels_ref))
-    assert_allclose(weights, weights_ref, atol=1e-12)
+    np.testing.assert_array_equal(np.asarray(weights), np.asarray(weights_ref))
 
 
 def test_get_interp_weights_centers_float32_precision(x64):
@@ -384,8 +390,14 @@ def test_get_interp_weights_centers_float32_precision(x64):
     dtype = np.float64 if x64 else np.float32
     theta, phi = _branch_targets(nside, 'north cap', n=500)
 
-    _, _, centers = jhp.get_interp_weights(nside, jnp.asarray(theta, dtype), jnp.asarray(phi, dtype), with_centers=True)
+    t_in, p_in = jnp.asarray(theta, dtype), jnp.asarray(phi, dtype)
+    pixels_ref, weights_ref = jhp.get_interp_weights(nside, t_in, p_in)
+    pixels_c, weights_c, centers = jhp.get_interp_weights(nside, t_in, p_in, with_centers=True)
     assert centers.z.dtype == dtype
+
+    # the flag must leave the weights bit-identical in this precision too
+    np.testing.assert_array_equal(np.asarray(pixels_c), np.asarray(pixels_ref))
+    np.testing.assert_array_equal(np.asarray(weights_c), np.asarray(weights_ref))
 
     pixels, _, _ = jhp.get_interp_weights(nside, theta, phi, with_centers=True)
     theta_ref, phi_ref = hp.pix2ang(nside, np.asarray(pixels))

--- a/tests/pixelfunc/test_interp.py
+++ b/tests/pixelfunc/test_interp.py
@@ -1,5 +1,7 @@
 """Tests for get_interp_weights function."""
 
+from functools import partial
+
 import healpy as hp
 import jax
 import jax.numpy as jnp
@@ -273,6 +275,238 @@ def test_get_interp_weights_gradient():
     # Since sum of weights is always 1, gradients should be 0
     assert_allclose(grad_theta, 0.0, atol=1e-10)
     assert_allclose(grad_phi, 0.0, atol=1e-10)
+
+
+# Tests for get_interp_weights(with_centers=True)
+
+
+def _branch_targets(nside, branch, n=2000, seed=0):
+    """Sample targets that land in a chosen branch of the interpolation.
+
+    The pole branches are entered when the target lies inside ring 1 (or the last ring),
+    a window that shrinks as ~1/nside, so it has to be sized from nside. Drawing
+    uniformly on the sphere puts almost nothing in it and hides pole-branch bugs.
+    """
+    rng = np.random.default_rng(seed)
+    theta_ring1 = np.arccos(1.0 - 1.0 / (3.0 * nside**2))
+
+    if branch == 'north cap':
+        theta = rng.uniform(1e-9, 0.98 * theta_ring1, n)
+    elif branch == 'south cap':
+        theta = np.pi - rng.uniform(1e-9, 0.98 * theta_ring1, n)
+    elif branch == 'belt':
+        theta = rng.uniform(1.5 * theta_ring1, np.pi - 1.5 * theta_ring1, n)
+    else:
+        raise ValueError(branch)
+
+    return theta, rng.uniform(0, 2 * np.pi, n)
+
+
+def _assert_in_branch(nside, theta, branch):
+    """Guard the sampler: a test that misses its branch would pass vacuously."""
+    from jax_healpy.pixelfunc import _ring_above
+
+    ir1 = np.asarray(_ring_above(nside, jnp.cos(jnp.asarray(theta))))
+    if branch == 'north cap':
+        assert np.all(ir1 == 0)
+    elif branch == 'south cap':
+        assert np.all(ir1 + 1 == 4 * nside)
+    else:
+        assert np.all((ir1 != 0) & (ir1 + 1 != 4 * nside))
+
+
+@pytest.mark.parametrize('branch', ['north cap', 'belt', 'south cap'])
+@pytest.mark.parametrize('nside', [4, 16, 64, 256, 512, 1024])
+def test_get_interp_weights_centers_match_pix2ang(nside, branch):
+    """Centers must describe the returned pixels, row for row, in every branch."""
+    theta, phi = _branch_targets(nside, branch)
+    _assert_in_branch(nside, theta, branch)
+
+    pixels, _, centers = jhp.get_interp_weights(nside, theta, phi, with_centers=True)
+    theta_ref, phi_ref = hp.pix2ang(nside, np.asarray(pixels))
+
+    # rows 0,1 lie on the first ring and rows 2,3 on the second
+    row_ring = np.array([0, 0, 1, 1])
+    assert_allclose(np.asarray(centers.z)[row_ring], np.cos(theta_ref), atol=1e-12)
+    assert_allclose(np.asarray(centers.s)[row_ring], np.sin(theta_ref), atol=1e-12)
+
+    dphi = (np.asarray(centers.phi) - phi_ref + np.pi) % (2 * np.pi) - np.pi
+    assert_allclose(dphi, 0.0, atol=1e-12)
+
+
+@pytest.mark.parametrize('branch', ['north cap', 'south cap'])
+@pytest.mark.parametrize('nside', [4, 16, 64, 512])
+def test_get_interp_weights_centers_two_rings_degenerate_in_caps(nside, branch):
+    """Inside a cap all four neighbours lie on one ring, so the two entries coincide."""
+    theta, phi = _branch_targets(nside, branch)
+    _, _, centers = jhp.get_interp_weights(nside, theta, phi, with_centers=True)
+
+    assert_allclose(centers.z[0], centers.z[1], atol=1e-15)
+    assert_allclose(centers.s[0], centers.s[1], atol=1e-15)
+
+
+@pytest.mark.parametrize('branch', ['north cap', 'belt', 'south cap'])
+@pytest.mark.parametrize('nside', [16, 128])
+def test_get_interp_weights_centers_shapes_and_ranges(nside, branch):
+    theta, phi = _branch_targets(nside, branch, n=50)
+    pixels, weights, centers = jhp.get_interp_weights(nside, theta, phi, with_centers=True)
+
+    assert pixels.shape == (4, 50)
+    assert weights.shape == (4, 50)
+    assert centers.z.shape == (2, 50)
+    assert centers.s.shape == (2, 50)
+    assert centers.phi.shape == (4, 50)
+
+    assert np.all(np.asarray(centers.s) >= 0.0)
+    assert np.all((np.asarray(centers.phi) >= 0.0) & (np.asarray(centers.phi) < 2 * np.pi))
+
+
+@pytest.mark.parametrize('branch', ['north cap', 'belt', 'south cap'])
+@pytest.mark.parametrize('nside', [16, 128])
+def test_get_interp_weights_centers_do_not_perturb_pixels(nside, branch):
+    """Asking for centers must not change what the function returns otherwise."""
+    theta, phi = _branch_targets(nside, branch)
+
+    pixels_ref, weights_ref = jhp.get_interp_weights(nside, theta, phi)
+    pixels, weights, _ = jhp.get_interp_weights(nside, theta, phi, with_centers=True)
+
+    np.testing.assert_array_equal(np.asarray(pixels), np.asarray(pixels_ref))
+    assert_allclose(weights, weights_ref, atol=1e-12)
+
+
+def test_get_interp_weights_centers_float32_precision(x64):
+    """Centers must stay accurate in float32, which is how furax runs the pipeline.
+
+    The weights themselves lose precision at high nside in float32, but the centers are
+    read off the ring geometry and must not.
+    """
+    nside = 512
+    dtype = np.float64 if x64 else np.float32
+    theta, phi = _branch_targets(nside, 'north cap', n=500)
+
+    _, _, centers = jhp.get_interp_weights(nside, jnp.asarray(theta, dtype), jnp.asarray(phi, dtype), with_centers=True)
+    assert centers.z.dtype == dtype
+
+    pixels, _, _ = jhp.get_interp_weights(nside, theta, phi, with_centers=True)
+    theta_ref, phi_ref = hp.pix2ang(nside, np.asarray(pixels))
+
+    tol = 1e-12 if x64 else 1e-6
+    assert_allclose(np.asarray(centers.z)[[0, 0, 1, 1]], np.cos(theta_ref), atol=tol)
+    assert_allclose(np.asarray(centers.s)[[0, 0, 1, 1]], np.sin(theta_ref), atol=tol)
+    dphi = (np.asarray(centers.phi) - phi_ref + np.pi) % (2 * np.pi) - np.pi
+    assert_allclose(dphi, 0.0, atol=tol)
+
+
+def test_get_interp_weights_centers_jit_and_pytree():
+    """InterpCenters is a NamedTuple, so it crosses a jit boundary as a pytree."""
+    nside = 32
+    theta, phi = _branch_targets(nside, 'belt', n=100)
+    theta, phi = jnp.asarray(theta), jnp.asarray(phi)
+
+    @partial(jax.jit, static_argnames=['nside'])
+    def run(nside, theta, phi):
+        return jhp.get_interp_weights(nside, theta, phi, with_centers=True)
+
+    _, _, centers = run(nside, theta, phi)
+
+    assert isinstance(centers, jhp.InterpCenters)
+    assert len(jax.tree.leaves(centers)) == 3
+
+    z, s, p = centers  # also unpacks as a plain tuple
+    assert_allclose(z, centers.z)
+    assert_allclose(s, centers.s)
+    assert_allclose(p, centers.phi)
+
+
+def test_get_interp_weights_centers_vmap():
+    nside = 32
+    theta, phi = _branch_targets(nside, 'belt', n=100)
+    theta, phi = jnp.asarray(theta), jnp.asarray(phi)
+
+    _, _, batched = jhp.get_interp_weights(nside, theta, phi, with_centers=True)
+    _, _, mapped = jax.vmap(lambda t, p: jhp.get_interp_weights(nside, t, p, with_centers=True))(theta, phi)
+
+    assert_allclose(jnp.swapaxes(mapped.z, 0, 1), batched.z)
+    assert_allclose(jnp.swapaxes(mapped.phi, 0, 1), batched.phi)
+
+
+@pytest.mark.parametrize('branch', ['north cap', 'belt', 'south cap'])
+def test_get_interp_weights_centers_have_zero_gradient(branch):
+    """Centers are fixed grid points: piecewise constant, so exactly zero tangents.
+
+    The polar sine goes through a sqrt that would produce a NaN gradient at the pole if
+    any differentiable path reached it, so this also guards against NaN.
+    """
+    nside = 32
+    theta, phi = _branch_targets(nside, branch, n=100)
+    theta, phi = jnp.asarray(theta), jnp.asarray(phi)
+
+    def summed_centers(theta, phi):
+        _, _, centers = jhp.get_interp_weights(nside, theta, phi, with_centers=True)
+        return centers.z.sum() + centers.s.sum() + centers.phi.sum()
+
+    grad_theta, grad_phi = jax.grad(summed_centers, argnums=(0, 1))(theta, phi)
+
+    np.testing.assert_array_equal(np.asarray(grad_theta), 0.0)
+    np.testing.assert_array_equal(np.asarray(grad_phi), 0.0)
+
+
+def test_get_interp_weights_centers_keep_gradient_of_weights():
+    """The flag must not disturb the gradient that flows through the weights."""
+    nside = 32
+    theta, phi = _branch_targets(nside, 'belt', n=100)
+    theta, phi = jnp.asarray(theta), jnp.asarray(phi)
+    map_data = jnp.asarray(np.random.default_rng(1).normal(size=jhp.nside2npix(nside)))
+
+    def interp(theta, phi, with_centers):
+        out = jhp.get_interp_weights(nside, theta, phi, with_centers=with_centers)
+        pixels, weights = out[0], out[1]
+        return jnp.sum(weights * map_data[pixels], axis=0)
+
+    jac = jax.jacfwd(interp, argnums=(0, 1))
+    grad_with = jac(theta, phi, True)
+    grad_without = jac(theta, phi, False)
+
+    assert np.all(np.isfinite(np.asarray(grad_with[0])))
+    assert_allclose(grad_with[0], grad_without[0], atol=1e-12)
+    assert_allclose(grad_with[1], grad_without[1], atol=1e-12)
+
+
+def test_get_interp_weights_centers_operator_is_transposable():
+    """A spin-2 interpolation built on the centers stays linear in the map.
+
+    This is the property furax needs: the centers enter as constants, so the operator has
+    a transpose and <Ax, y> == <x, A^T y>.
+    """
+    nside = 32
+    rng = np.random.default_rng(2)
+    theta, phi = _branch_targets(nside, 'belt', n=200)
+    theta, phi = jnp.asarray(theta), jnp.asarray(phi)
+
+    pixels, weights, centers = jhp.get_interp_weights(nside, theta, phi, with_centers=True)
+
+    # a spin-2 rotation by the transport angle between each neighbour and the target
+    z_row = centers.z[jnp.array([0, 0, 1, 1])]
+    dphi = centers.phi - phi
+    alpha = 2.0 * jnp.arctan2(jnp.sin(dphi) * z_row, 1.0 + jnp.cos(dphi))
+    cos_alpha, sin_alpha = jnp.cos(alpha), jnp.sin(alpha)
+
+    def apply(qu):
+        q, u = qu[0][pixels], qu[1][pixels]
+        q_rot = cos_alpha * q - sin_alpha * u
+        u_rot = sin_alpha * q + cos_alpha * u
+        return jnp.stack([jnp.sum(weights * q_rot, axis=0), jnp.sum(weights * u_rot, axis=0)])
+
+    qu = jnp.asarray(rng.normal(size=(2, jhp.nside2npix(nside))))
+    y = jnp.asarray(rng.normal(size=(2, theta.size)))
+    (transposed,) = jax.linear_transpose(apply, qu)(y)
+
+    assert_allclose(jnp.sum(apply(qu) * y), jnp.sum(qu * transposed), rtol=1e-12)
+
+
+def test_get_interp_weights_centers_nest_error():
+    with pytest.raises(ValueError, match='NEST'):
+        jhp.get_interp_weights(16, jnp.array([1.0]), jnp.array([0.0]), nest=True, with_centers=True)
 
 
 # Tests for get_interp_val

--- a/tests/pixelfunc/test_interp.py
+++ b/tests/pixelfunc/test_interp.py
@@ -463,10 +463,17 @@ def test_get_interp_weights_centers_have_zero_gradient(branch):
     np.testing.assert_array_equal(np.asarray(grad_phi), 0.0)
 
 
-def test_get_interp_weights_centers_keep_gradient_of_weights():
-    """The flag must not disturb the gradient that flows through the weights."""
-    nside = 32
-    theta, phi = _branch_targets(nside, 'belt', n=100)
+@pytest.mark.parametrize('mode', ['jacfwd', 'jacrev'])
+@pytest.mark.parametrize('branch', ['north cap', 'belt', 'south cap'])
+def test_get_interp_weights_centers_keep_gradient_of_weights(branch, mode):
+    """The flag must not disturb the gradient that flows through the weights.
+
+    Bit equality, for the same reason as the weights themselves: the gradient is
+    differentiated from the forward graph, so pinning that graph pins the gradient.
+    Reverse mode is covered because that is what an adjoint or a CG solve exercises.
+    """
+    nside = 128
+    theta, phi = _branch_targets(nside, branch, n=100)
     theta, phi = jnp.asarray(theta), jnp.asarray(phi)
     map_data = jnp.asarray(np.random.default_rng(1).normal(size=jhp.nside2npix(nside)))
 
@@ -475,13 +482,14 @@ def test_get_interp_weights_centers_keep_gradient_of_weights():
         pixels, weights = out[0], out[1]
         return jnp.sum(weights * map_data[pixels], axis=0)
 
-    jac = jax.jacfwd(interp, argnums=(0, 1))
+    jac = {'jacfwd': jax.jacfwd, 'jacrev': jax.jacrev}[mode](interp, argnums=(0, 1))
     grad_with = jac(theta, phi, True)
     grad_without = jac(theta, phi, False)
 
     assert np.all(np.isfinite(np.asarray(grad_with[0])))
-    assert_allclose(grad_with[0], grad_without[0], atol=1e-12)
-    assert_allclose(grad_with[1], grad_without[1], atol=1e-12)
+    assert np.all(np.isfinite(np.asarray(grad_with[1])))
+    np.testing.assert_array_equal(np.asarray(grad_with[0]), np.asarray(grad_without[0]))
+    np.testing.assert_array_equal(np.asarray(grad_with[1]), np.asarray(grad_without[1]))
 
 
 def test_get_interp_weights_centers_operator_is_transposable():


### PR DESCRIPTION
## Motivation

Interpolating Q and U as scalars is wrong. HEALPix stores them in each pixel's local meridian basis, so the four interpolation neighbours are expressed in four different bases. Combining them correctly needs a per-neighbour spin-2 rotation by the transport angle between the neighbour's center and the interpolation target.

That rotation needs each neighbour's center. `get_interp_weights` returned only `(pixels, weights)`, so a caller had to recover the centers with a second `pix2ang` pass over the four neighbours. `_get_interp_weights_ring` already computes the ring geometry those centers come from, and discarded it.

## What this adds

A `with_centers` keyword on `get_interp_weights`.

```python
pixels, weights, centers = get_interp_weights(nside, theta, phi, with_centers=True)
# centers.z    (2, *dims)  cos(theta) of the two rings
# centers.s    (2, *dims)  sin(theta) of the two rings
# centers.phi  (4, *dims)  longitude of each neighbour, aligned with `pixels`
```

`centers` is an `InterpCenters`, a `NamedTuple` and therefore a JAX pytree.

The four neighbours lie on only two rings. Rows 0 and 1 of `pixels` share the first ring and rows 2 and 3 share the second, so co-latitude takes two values per sample rather than four. Co-latitude is returned as a cosine and a sine because that is the form the ring geometry produces natively, and forming the angle would round twice.

**Centers are constants, by design.**
Pixel centers are fixed points of the HEALPix grid, so as a function of the input coordinates they are a step function. Their derivative is zero on the interior of every pixel cell. It does not exist on the cell boundaries, where the selected neighbour changes and the center jumps. Those boundaries are the ring co-latitudes in $\theta$ and the pixel edges in $\varphi$, which form a measure-zero set.

`stop_gradient` makes the zero explicit and keeps the polar `sqrt` from producing a NaN tangent at the pole. On a boundary JAX then returns zero, which is the one-sided derivative from both sides. No finite value is the derivative of a jump, so this is the same convention the existing pixel-index `stop_gradient` already uses.

Holding the centers constant is also what keeps an interpolation operator built on them linear in the map, and therefore transposable.

## Transform support

Verified: `jit`, `vmap`, `jvp`, `vjp`, `jacfwd`, `jacrev`, `grad`, `hessian`, `lax.scan`, and combinations of these.

`jax.linear_transpose` applies to an operator built from the output, not to `get_interp_weights` itself. `get_interp_weights` is not linear in `theta` and `phi`, and transposing it raises `RuntimeError`.

The operator below is linear in the map, because `pixels`, `weights` and `centers` are all constants with respect to it.

```python
pixels, weights, centers = jhp.get_interp_weights(nside, theta, phi, with_centers=True)

# spin-2 transport angle from each neighbour's centre to the target
z = centers.z[jnp.array([0, 0, 1, 1])]          # cos(theta) per neighbour
dphi = centers.phi - phi
alpha = 2.0 * jnp.arctan2(jnp.sin(dphi) * z, 1.0 + jnp.cos(dphi))
cos_a, sin_a = jnp.cos(alpha), jnp.sin(alpha)

def interpolate_qu(qu):
    """Interpolate a (2, npix) Q/U map onto the targets, rotating each neighbour."""
    q, u = qu[0][pixels], qu[1][pixels]
    return jnp.stack([
        jnp.sum(weights * (cos_a * q - sin_a * u), axis=0),
        jnp.sum(weights * (sin_a * q + cos_a * u), axis=0),
    ])

(qu_adjoint,) = jax.linear_transpose(interpolate_qu, qu)(tod)
```

Run at nside 32 in float64 with 500 targets, this satisfies $\langle A\,x,\,y\rangle = \langle x,\,A^{\mathsf{T}}y\rangle$ to a relative $3.7\times 10^{-16}$. The same identity holds to a relative $6.6\times 10^{-16}$ when the weights and centers are recomputed inside `interpolate_qu` rather than closed over. That second case is the one an iterative solver exercises.

## Implementation note

`_get_ring_costheta_sintheta` is a new helper rather than an extra return value on `_get_ring_info`. `_get_ring_info` forms cosine and sine directly only in its polar branch, and its equatorial branch goes straight to `arccos` without ever forming a sine. Both helpers run in the same jit trace on the same ring index, so common-subexpression elimination already shares the overlap. A merged prototype was tested and measured 1.756 ms against 1.740 ms for the current split, at nside 1024 over 200000 ring indices in float64, so merging would recover nothing.

## Compatibility

`with_centers` defaults to `False` and the two-value return is unchanged. Pixel selection is identical between the two settings at every nside and dtype tested. Pixels and weights are bit-identical between the two settings, at nside 16, 64, 256 and 1024 in both float32 and float64. 

That equality needs one `optimization_barrier` and does not come for free. The centers share subexpressions with the weights, and giving those nodes a second consumer changes how XLA fuses them. The co-latitude weight then divides by $\theta_2 - \theta_1 \approx 1/n_{\text{side}}$, which amplifies a one-ulp change by roughly $n_{\text{side}}$.

Without the barrier the effect is small but systematic rather than random. Over 30 seeds at each of nside 16, 64, 256 and 1024 in float64, `with_centers=True` was closer to a `healpy` reference in 0 of 120 trials, tied in 35, and further in 85, by a median factor of 1.01 to 1.15 and a worst case of 1.85. Reading the ring geometry through a barrier removes this and costs 0.25 ms of the 15.33 ms total at nside 1024 with 200000 samples in float64.

## Tests

Eleven tests in `tests/pixelfunc/test_interp.py`, 48 parametrised cases.
They cover the three branches separately, the two-rings degeneracy in the caps, shapes and ranges, float32 precision, jit, the pytree round trip, `vmap`, zero center gradients, unchanged weight gradients, and the transpose identity.